### PR TITLE
threadmap: Fixes incorrect zero-padding of addresses in disassembly

### DIFF
--- a/KSLGroup_Threadmap/threadmap.py
+++ b/KSLGroup_Threadmap/threadmap.py
@@ -160,7 +160,7 @@ class ThreadFindings(object):
                 else:
                     mode = distorm3.Decode32Bits
 
-                disassemble_code += "\n\t".join(["{0:<#010x} {1:<16} {2}".format(o, h, i) \
+                disassemble_code += "\n\t".join(["{0:#010x} {1:<16} {2}".format(o, h, i) \
                                               for o, _size, i, h in \
                                               distorm3.DecodeGenerator(entry_point, content, mode)])
 


### PR DESCRIPTION
The same patch was submitted to the original repository.

https://github.com/kslgroup/threadmap/pull/1

Please merge or pull from upstream once merged there.